### PR TITLE
Bump mysql56 to stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "cweagans/composer-patches": "^1.6",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",
-        "drupal/mysql56": "^1.0@beta"
+        "drupal/mysql56": "^1.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Per discussion in ORCA Slack, this will unblock some other things. This dependency was added last year when only a beta was available, I think that's the only reason it was constrained to beta at the time.