### PR TITLE
Composer should exit on patch failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "sort-packages": true
     },
     "extra": {
+        "composer-exit-on-patch-failure": true,
         "drupal-scaffold": {
             "allowed-packages": [
                 "acquia/acquia_cms"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "acquia/acquia_cms": "^1.2",
+        "acquia/acquia_cms": "^1.3.2",
         "acquia/blt": "^12",
         "acquia/blt-phpcs": "^1.0",
         "acquia/drupal-environment-detector": "^1",


### PR DESCRIPTION
Also force update of Acquia CMS. Older versions are broken due to patch failures and unconstrained dependencies, and can get installed unintentionally due to missing PHP extensions.