### PR TITLE
Explain gitignore mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Files and directories suggested to be ignored by Drupal
-# @see https://git.drupalcode.org/project/drupal/-/blob/9.2.x/example.gitignore
+# We allow settings.php to be committed since Acquia's filesystem is read-only
+# @see https://git.drupalcode.org/project/drupal/-/blob/9.3.x/example.gitignore
+# @see https://www.drupal.org/project/drupal/issues/3257119
 /docroot/core
 /vendor/
 /docroot/sites/*/settings.*.php

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Files and directories suggested to be ignored by Drupal
-# We allow settings.php to be committed since Acquia's filesystem is read-only
 # @see https://git.drupalcode.org/project/drupal/-/blob/9.3.x/example.gitignore
+#
+# We allow settings.php to be committed since Acquia's filesystem is read-only
 # @see https://www.drupal.org/project/drupal/issues/3257119
 /docroot/core
 /vendor/


### PR DESCRIPTION
Drupal core doesn't commit settings.php because it's automatically created at install time. But this isn't possible on Acquia Cloud's read-only fs.

This explains the confusion in https://github.com/acquia/drupal-recommended-project/pull/63 .