### PR TITLE
ACMS-1320: Headless Next.js starter kit oauth keys need to support Acquia Cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ local.site.yml
 local.services.yml
 *.local
 local.blt.yml
+
+# oauth keys
+oauth_keys/


### PR DESCRIPTION
Headless Next.js starter kit oauth keys need to support Acquia Cloud

**Motivation**
./oauth_keys is the location where there keys are stored which is not covered by .gitignore from the drupal-recommended-project. This could lead to customers committing oauth keys to their git repositories.
Fixes #ACMS-1320

**Proposed changes**
Add ./oauth_keys in .gitignore

**Alternatives considered**
NA

**Testing steps**
- Create project with this codebase
- init git repo
- install headless starterkit `./vendor/bin/acms acms:install acquia_cms_headless`
- now with `git status` newly created ./oauth_keys directory should not be listed.
