### PR TITLE
Enable d10-jobs

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -36,6 +36,8 @@ jobs:
           - INTEGRATED_TEST_ON_NEXT_MINOR_DEV
           - ISOLATED_TEST_ON_NEXT_MINOR_DEV
           - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
+          - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
           # This is our custom job on 7.4
           - ""
           # We do not run deprecated code scans since they'd scan the entire
@@ -49,6 +51,10 @@ jobs:
           # These are our custom jobs to ensure composer install works
           - orca-job: ""
             php-version: "8.0"
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.1"
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.1"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -36,8 +36,6 @@ jobs:
           - INTEGRATED_TEST_ON_NEXT_MINOR_DEV
           - ISOLATED_TEST_ON_NEXT_MINOR_DEV
           - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
-          - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
           # This is our custom job on 7.4
           - ""
           # We do not run deprecated code scans since they'd scan the entire
@@ -54,6 +52,10 @@ jobs:
           - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
             php-version: "8.1"
           - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.1"
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.1"
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
             php-version: "8.1"
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**Motivation**
Enables jobs to test D10 readiness . [ORCA-411](https://backlog.acquia.com/browse/ORCA-411)

**Proposed changes**
Enabled the following jobs
1. ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
2. INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
3. ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
4. INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
