### PR TITLE
Upgrade node version to 16.x

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
This to upgrade node version  to 16.x as 12.x is deprecated and throwing multiple warnings.

