### PR TITLE
ORCA-475: Removing http-hmac-php and Integrate with ORCA

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -1,0 +1,99 @@
+---
+name: ORCA CI
+on:
+  push:
+    # Prevent duplicate jobs on Dependabot PRs that interfere with automerge.
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      ORCA_SUT_NAME: acquia/drupal-recommended-project
+      ORCA_SUT_BRANCH: master
+      ORCA_VERSION: ^3
+      ORCA_JOB: ${{ matrix.orca-job }}
+
+    strategy:
+      matrix:
+        orca-job:
+          # d10-jobs
+          - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+          - STATIC_CODE_ANALYSIS
+          # - STATIC_CODE_ANALYSIS
+          # - INTEGRATED_TEST_ON_OLDEST_SUPPORTED
+          # - INTEGRATED_TEST_ON_PREVIOUS_MINOR
+          # - INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR
+          # - ISOLATED_TEST_ON_CURRENT
+          # - INTEGRATED_TEST_ON_CURRENT
+          # - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR
+          # - ISOLATED_TEST_ON_CURRENT_DEV
+          # - INTEGRATED_TEST_ON_CURRENT_DEV
+          # - ISOLATED_TEST_ON_NEXT_MINOR
+          # - INTEGRATED_TEST_ON_NEXT_MINOR
+          # - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_BETA_OR_LATER
+          # - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_DEV
+          # - INTEGRATED_TEST_ON_NEXT_MINOR_DEV
+          # - ISOLATED_TEST_ON_NEXT_MINOR_DEV
+          # - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
+          # This is our custom job on 7.4
+          # - ""
+          # We do not run deprecated code scans since they'd scan the entire
+          # codebase (since the SUT is the project template).
+        php-version: [ "8.1" ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: xdebug2
+
+      - name: Before install
+        run: |
+          composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"
+          curl https://patch-diff.githubusercontent.com/raw/acquia/orca/pull/294.patch | git -C ../orca apply
+          ../orca/bin/ci/before_install.sh
+          if [[ ! "$ORCA_JOB" ]]; then composer install; fi
+
+      - name: Install
+        run: ../orca/bin/ci/install.sh
+
+      - name: Before script
+        run: ../orca/bin/ci/before_script.sh
+
+      - name: Script
+        run: ../orca/bin/ci/script.sh
+
+      - name: After script
+        run: ../orca/bin/ci/after_script.sh
+
+      - name: After success
+        if: ${{ success() }}
+        run: ../orca/bin/ci/after_success.sh
+
+      - name: After failure
+        if: ${{ failure() }}
+        run: ../orca/bin/ci/after_failure.sh
+
+  # Require all checks to pass without having to enumerate them in the branch protection UI.
+  # @see https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957
+  all-successful:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
+    - name: All checks successful
+      run: echo "🎉"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "php": ">=8.1",
         "acquia/drupal-environment-detector": "^1",
-        "acquia/http-hmac-php": "6.0.0",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.6",
         "drupal/core-composer-scaffold": "^10.0.0-alpha1",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.1",
         "acquia/drupal-environment-detector": "^1",
-        "acquia/http-hmac-php": "3.4.0",
+        "acquia/http-hmac-php": "6.0.0",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.6",
         "drupal/core-composer-scaffold": "^10.0.0-alpha1",


### PR DESCRIPTION
Latest version of Acquia Search requires acquia/http-hmac-php >=5 , we are updating this to version 6.0.0 here to have parity with main branch . Details in https://backlog.acquia.com/browse/ORCA-475.
