### PR TITLE
ACMS-1629: Restrict Drupal Core to 9.x release for 1.x branch of DRP.

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -24,39 +24,43 @@ jobs:
           - INTEGRATED_TEST_ON_OLDEST_SUPPORTED
           - INTEGRATED_TEST_ON_PREVIOUS_MINOR
           - INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR
-          - ISOLATED_TEST_ON_CURRENT
-          - INTEGRATED_TEST_ON_CURRENT
-          - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR
-          - ISOLATED_TEST_ON_CURRENT_DEV
-          - INTEGRATED_TEST_ON_CURRENT_DEV
-          - ISOLATED_TEST_ON_NEXT_MINOR
-          - INTEGRATED_TEST_ON_NEXT_MINOR
-          - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_BETA_OR_LATER
-          - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_DEV
-          - INTEGRATED_TEST_ON_NEXT_MINOR_DEV
-          - ISOLATED_TEST_ON_NEXT_MINOR_DEV
-          - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           # This is our custom job on 7.4
           - ""
+          # Drupal core restricted to 9.x, upgrade not possible. So, skipping.
+          #- ISOLATED_TEST_ON_NEXT_MINOR
+          #- INTEGRATED_TEST_ON_NEXT_MINOR
+          #- ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_BETA_OR_LATER
+          #- ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_DEV
+          #- ISOLATED_TEST_ON_CURRENT
+          #- INTEGRATED_TEST_ON_CURRENT
+          #- ISOLATED_TEST_ON_CURRENT_DEV
+          #- INTEGRATED_TEST_ON_CURRENT_DEV
+          #- INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR
+          #- INTEGRATED_TEST_ON_NEXT_MINOR_DEV
+          #- ISOLATED_TEST_ON_NEXT_MINOR_DEV
+          #- INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           # We do not run deprecated code scans since they'd scan the entire
           # codebase (since the SUT is the project template).
         php-version: [ "7.4" ]
         include:
-          - orca-job: ISOLATED_TEST_ON_CURRENT
+          - orca-job: INTEGRATED_TEST_ON_OLDEST_SUPPORTED
             php-version: "8.0"
-          - orca-job: ISOLATED_TEST_ON_CURRENT
+          - orca-job: INTEGRATED_TEST_ON_OLDEST_SUPPORTED
+            php-version: "8.1"
+            # ORCA doesn't support ISOLATED_TEST_ON_PREVIOUS_MINOR, so used
+            # INTEGRATED_TEST_ON_PREVIOUS_MINOR to verify on PHP 8.0 & PHP 8.1.
+            # This will fail after Drupal core 10.0.1. So remove this later.
+          - orca-job: INTEGRATED_TEST_ON_PREVIOUS_MINOR
+            php-version: "8.0"
+          - orca-job: INTEGRATED_TEST_ON_PREVIOUS_MINOR
+            php-version: "8.1"
+          - orca-job: INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR
+            php-version: "8.0"
+          - orca-job: INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR
             php-version: "8.1"
           # These are our custom jobs to ensure composer install works
           - orca-job: ""
             php-version: "8.0"
-          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.1"
-          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.1"
-          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-            php-version: "8.1"
-          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-            php-version: "8.1"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -54,10 +54,6 @@ jobs:
             php-version: "8.0"
           - orca-job: INTEGRATED_TEST_ON_PREVIOUS_MINOR
             php-version: "8.1"
-          - orca-job: INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR
-            php-version: "8.0"
-          - orca-job: INTEGRATED_UPGRADE_TEST_FROM_PREVIOUS_MINOR
-            php-version: "8.1"
           # These are our custom jobs to ensure composer install works
           - orca-job: ""
             php-version: "8.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "acquia/memcache-settings": "^1",
         "composer/installers": "^2.1",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-composer-scaffold": "^10",
+        "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",
         "drupal/upgrade_status": "^3.13",
         "drush/drush": "^10.6 || ^11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4723aafdf817b5b9a1b1648bb7b6a9b",
+    "content-hash": "9f11d06390f29ac0c7319ca4c8ee90f1",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -2106,20 +2106,20 @@
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "10.0.1",
+            "version": "9.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
-                "reference": "e3f17745ab88a919f5179e6d9c1ac8ce77d3845f"
+                "reference": "df1f779d3f94500f6cc791427aa729e0ba4b2464"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-composer-scaffold/zipball/e3f17745ab88a919f5179e6d9c1ac8ce77d3845f",
-                "reference": "e3f17745ab88a919f5179e6d9c1ac8ce77d3845f",
+                "url": "https://api.github.com/repos/drupal/core-composer-scaffold/zipball/df1f779d3f94500f6cc791427aa729e0ba4b2464",
+                "reference": "df1f779d3f94500f6cc791427aa729e0ba4b2464",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^2",
+                "composer-plugin-api": "^1 || ^2",
                 "php": ">=7.3.0"
             },
             "conflict": {
@@ -2150,9 +2150,9 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/10.0.1"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.5.1"
             },
-            "time": "2022-07-01T08:33:05+00:00"
+            "time": "2022-06-19T16:14:18+00:00"
         },
         {
             "name": "drupal/core-recommended",


### PR DESCRIPTION
**Motivation**
Make a new release for 1.x branch of DRP.

**Proposed changes**
- Restrict Drupal Core to 9.x.
- Updated ORCA CI to tests on only 9.x release.

**Alternatives considered**
N/A

**Testing steps**
- ORCA CI tests should pass.
- Manual Testing
