### PR TITLE
ACMS-1629: Updated README.md file and remove acquia/http-hmac-php as per ORCA-475.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Acquia Drupal Recommended Project
 ====
 
-This is a project template providing a great out-of-the-box experience for new Drupal 9 projects hosted on Acquia. It is based on the [Drupal Recommended Project](https://github.com/drupal/recommended-project/tree/9.0.x) and similar to the [Acquia Drupal Minimal Project](https://github.com/acquia/drupal-minimal-project), with the principal difference being the addition of several modules and packages that provide the best possible out-of-the-box experience for Acquia customers.
+This is a project template providing a great out-of-the-box experience for new Drupal 10 projects hosted on Acquia. It is based on the [Drupal Recommended Project](https://github.com/drupal/recommended-project/tree/9.0.x), with the principal difference being the addition of several modules and packages that provide the best possible out-of-the-box experience for Acquia customers.
 
 This project includes the following packages and configuration:
 * [Drupal core](https://www.drupal.org/project/drupal)
@@ -11,7 +11,7 @@ This project includes the following packages and configuration:
 * [Asset Packagist](https://asset-packagist.org/) repository, package, and configuration
 * [Acquia environment detection](https://github.com/acquia/drupal-environment-detector)
 * [Acquia platform memcache settings](https://github.com/acquia/memcache-settings)
-* Best practices for Drupal development, testing and project architcture
+* Best practices for Drupal development, testing and project architecture
 
 The Acquia CMS starter kit allows you to install Drupal for a given style of CMS:
 
@@ -39,12 +39,10 @@ You should only commit changes to `composer.json` and `composer.lock`. Do not co
 
 ## Other Drupal versions
 
-Drupal 9 is installed by default. If you want to try Drupal 10, use the `drupal10` branch:
+Drupal 10 is installed by default. To install Drupal 9, use the below command:
 ```
-composer create-project acquia/drupal-recommended-project:dev-drupal10
+composer create-project acquia/drupal-recommended-project:^1
 ```
-
-Note that the `drupal10` branch is completely untested, lacks many packages with known compatibility issues, and is slightly more resource-intensive to install due to not shipping with a `composer.lock` file.
 
 ## Next steps
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "php": ">=7.4",
         "acquia/acquia-cms-starterkit": "^1",
         "acquia/drupal-environment-detector": "^1",
-        "acquia/http-hmac-php": "6.0.0",
         "acquia/memcache-settings": "^1",
         "composer/installers": "^2.1",
         "cweagans/composer-patches": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f11d06390f29ac0c7319ca4c8ee90f1",
+    "content-hash": "c53695820c66d61ce018196f73c90bde",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -132,67 +132,6 @@
                 "source": "https://github.com/acquia/drupal-environment-detector/tree/1.5.3"
             },
             "time": "2022-12-15T16:49:52+00:00"
-        },
-        {
-            "name": "acquia/http-hmac-php",
-            "version": "6.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/acquia/http-hmac-php.git",
-                "reference": "f4405aa98531b3d6b094b928495e93bc171b7758"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/acquia/http-hmac-php/zipball/f4405aa98531b3d6b094b928495e93bc171b7758",
-                "reference": "f4405aa98531b3d6b094b928495e93bc171b7758",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3.0",
-                "psr/http-message": "^1.0"
-            },
-            "replace": {
-                "acquia/hmac-request": "self.version"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.2.1",
-                "guzzlehttp/guzzle": "^6.0",
-                "nyholm/psr7": "^1.0",
-                "php-coveralls/php-coveralls": "^2.2",
-                "phpmd/phpmd": "^2.0",
-                "phpunit/phpunit": "^8.0",
-                "symfony/phpunit-bridge": "^4.0 || ^5.0",
-                "symfony/psr-http-message-bridge": "^2.0",
-                "symfony/security-bundle": "^4.0 || ^5.0"
-            },
-            "suggest": {
-                "guzzlehttp/guzzle": "^6.0",
-                "laminas/laminas-diactoros": "^1.8 || ^2.2",
-                "symfony/security": "^4.0 || ^5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Acquia\\Hmac\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "See contributors",
-                    "homepage": "https://github.com/acquia/http-hmac-php/graphs/contributors"
-                }
-            ],
-            "description": "An implementation of the HTTP HMAC Spec in PHP that integrates with popular libraries such as Symfony and Guzzle.",
-            "homepage": "https://github.com/acquia/http-hmac-php",
-            "support": {
-                "issues": "https://github.com/acquia/http-hmac-php/issues",
-                "source": "https://github.com/acquia/http-hmac-php/tree/6.0.0"
-            },
-            "time": "2021-10-21T21:17:37+00:00"
         },
         {
             "name": "acquia/memcache-settings",


### PR DESCRIPTION
**Motivation**
Updated Readme.md and remove package acquia/http-hmac-php as per ORCA-475.

**Proposed changes**
- The README.md file updated as per Drupal 10.
- The package `acquia/http-hmac-php` has been removed as per ORCA-475.

**Alternatives considered**
N/A.

**Testing steps**
- ORCA CI should pass.
