### PR TITLE
ACMS-1651: Add release drafter for 2.x & 1.x releases.

### DIFF
--- a/.github/release-drafter-1.x.yml
+++ b/.github/release-drafter-1.x.yml
@@ -1,7 +1,7 @@
 name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 filter-by-commitish: true
-commitish: 'master'
+commitish: '1.x'
 categories:
   - title: '🚨 Major changes'
     label: 'breaking change'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,5 +25,7 @@ jobs:
       pull-requests: read
     steps:
       - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml # located in .github/ in default branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Motivation**
Added github release drafter for 1.x & 2.x releases.

**Proposed changes**

- Added a new release drafter for 1.x, restricting to release from 1.x branch.
- Default release drafter updated to restrict release from master branch.
- Workflow for default release drafter updated to use default release drafter config.

**Alternatives considered**
N/A.

**Testing steps**
- CI should pass.
- Automatic release should be created.