### PR TITLE
ACMS-1651: Add release drafter for 1.x releases.

### DIFF
--- a/.github/workflows/release-drafter-1.x.yml
+++ b/.github/workflows/release-drafter-1.x.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - 1.x
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
@@ -25,5 +25,7 @@ jobs:
       pull-requests: read
     steps:
       - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-1.x.yml # located in .github/ in default branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The PR #293 needs to be merged first.

**Motivation**
Added github release drafter for 1.x release.

**Proposed changes**
- Release drafter configuration renamed.
- Release drafter configuration update to use release drafter 1.x configuration.

**Alternatives considered**
N/A.

**Testing steps**
- CI should pass.
- Automatic release should be created
