### PR TITLE
ACMS-1708: Fix the empty releases created by release-drafter.

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -36,5 +36,6 @@ jobs:
       - uses: release-drafter/release-drafter@v5
         with:
           publish: true
+          config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Motivation**
Fixes ACMS-1708

**Proposed changes**
The `Auto Merge` workflow config was missing the config-name parameter, due to which looks like workflow creating the release from default config which uses the master branch and thus create release for 2.x branch.

**Alternatives considered**
N/A.

**Testing steps**
Merge PR for 1.x branch & see if it create a release on 1.x (and not on 2.x).
