### PR TITLE
ACMS-1730: ignore Drush contrib commands.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /docroot/sites/simpletest
 
 # Directories specific to this template
+/drush/Commands/contrib
 /docroot/libraries
 /docroot/modules/contrib
 /docroot/profiles/contrib


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1730

**Proposed changes**
Ignore drush contrib commands i.e. `/drush/Commands/contrib`

**Alternatives considered**
NA

**Testing steps**
- Clone acquia/drupal-recommended-project using `git clone git@github.com:acquia/drupal-recommended-project.git`
- Include any drush plugin using composer
- check `git status` and it should not show anything from `/drush/Commands/contrib` to be available for commit.
