### PR TITLE
ACMS-1833: Provide support for Drush 12.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "cweagans/composer-patches": "^1.6",
         "drupal/core-composer-scaffold": "^10",
         "drupal/core-recommended": "^10",
-        "drush/drush": "^11",
+        "drush/drush": "^11 || ^12",
         "oomphinc/composer-installers-extender": "^2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4baff481741ea4cf44d640e4d9e8dd0e",
+    "content-hash": "afe5c1c92ff488cd883f2c2406a24db3",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",


### PR DESCRIPTION
**Motivation**
Fixes #ACMS-1833

**Proposed changes**
Provide support for Drush 12.

**Alternatives considered**
NA

**Testing steps**
- Create new project with ACMS-1833 branch
- Update drush to 12 using `composer require drush/drush:^12 -W`
- Install site using local drush `./vendor/bin/drush si minimal`
- Verify other drush commands using local drush
