### PR TITLE
ACMS-1934: Add drupal/config_sync_without_site_uuid project plugin.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "acquia/memcache-settings": "^1",
         "composer/installers": "^2.1",
         "cweagans/composer-patches": "^1.6",
+        "drupal/config_sync_without_site_uuid": "^1.0@beta",
         "drupal/core-composer-scaffold": "^10",
         "drupal/core-recommended": "^10",
         "drush/drush": "^12",
@@ -38,7 +39,8 @@
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
             "oomphinc/composer-installers-extender": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "php-http/discovery": true
         },
         "platform": {
             "php": "8.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee19ace3bb41dee43fe7c237e3258a2e",
+    "content-hash": "0b81576644ba28cfb94c3c9a2c483a14",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -1904,6 +1904,29 @@
                 }
             ],
             "time": "2022-12-14T08:49:07+00:00"
+        },
+        {
+            "name": "drupal/config_sync_without_site_uuid",
+            "version": "1.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_sync_without_site_uuid.git",
+                "reference": "2f6aea8a46553523b473c53dc2df87a76c2130a2"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "globals.php"
+                ],
+                "psr-4": {
+                    "Drupal\\ConfigSyncWithoutSiteUuid\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "time": "2023-03-13T16:14:16+00:00"
         },
         {
             "name": "drupal/core",
@@ -9904,7 +9927,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "drupal/config_sync_without_site_uuid": 10
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-1934](https://backlog.acquia.com/browse/ACMS-1934)

**Proposed changes**
Add drupal/config_sync_without_site_uuid project plugin.

**Alternatives considered**
NA

**Testing steps**
Follow from ticket.
