### PR TITLE
ACMS-1934: Add drupal/config_sync_without_site_uuid project plugin.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "acquia/memcache-settings": "^1",
         "composer/installers": "^2.1",
         "cweagans/composer-patches": "^1.6",
+        "drupal/config_sync_without_site_uuid": "^1.0@beta",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",
         "drupal/upgrade_status": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b1e1c05ad5d97eea2e92135a902f67a",
+    "content-hash": "ffdd314b87189754bf8a692b8a6d924c",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -1871,6 +1871,29 @@
             },
             "abandoned": "roave/better-reflection",
             "time": "2022-05-31T18:46:25+00:00"
+        },
+        {
+            "name": "drupal/config_sync_without_site_uuid",
+            "version": "1.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_sync_without_site_uuid.git",
+                "reference": "2f6aea8a46553523b473c53dc2df87a76c2130a2"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "globals.php"
+                ],
+                "psr-4": {
+                    "Drupal\\ConfigSyncWithoutSiteUuid\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "time": "2023-03-13T16:14:16+00:00"
         },
         {
             "name": "drupal/core",
@@ -10261,7 +10284,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "drupal/config_sync_without_site_uuid": 10
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
**Motivation**
Fixes #[ACMS-1934](https://backlog.acquia.com/browse/ACMS-1934)

**Proposed changes**
Add drupal/config_sync_without_site_uuid project plugin.

**Alternatives considered**
NA

**Testing steps**
Follow from ticket.
