### PR TITLE
Add Drupal 9 tests

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -67,6 +67,15 @@ jobs:
           - orca-job: ""
             php-version: "8.0"
             orca-version: "^3"
+
+          - orca-job: INTEGRATED_TEST_ON_LATEST_EOL_MAJOR
+            php-version: "8.1"
+            orca-version: "^4"
+
+         - orca-job: INTEGRATED_TEST_ON_LATEST_EOL_MAJOR
+           php-version: "8.0"
+           orca-version: "^3"
+
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
We are adding Drupal 9 tests for PHP 8.1 and PHP 8.0.