### PR TITLE
RCAT-684 | Enable D11 jobs

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -44,16 +44,10 @@ jobs:
           # Testing Drupal 11 in php 8.3.
           - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
             php-version: "8.3"
-
-          # Testing Drupal 11 in php 8.3.
           - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
             php-version: "8.3"
-
-          # Testing Drupal 11 in php 8.3.
           - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
             php-version: "8.3"
-
-          # Testing Drupal 11 in php 8.3.
           - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
             php-version: "8.3"
 

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -10,7 +10,7 @@ on:
     - cron: "0 0 * * *"
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       ORCA_SUT_NAME: acquia/drupal-recommended-project
       ORCA_SUT_BRANCH: master
@@ -40,7 +40,22 @@ jobs:
           # codebase (since the SUT is the project template).
         php-version: [ "8.1", "8.3" ]
         orca-version: [ "^4" ]
+        include:
+          # Testing Drupal 11 in php 8.3.
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.3"
 
+          # Testing Drupal 11 in php 8.3.
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.3"
+
+          # Testing Drupal 11 in php 8.3.
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.3"
+
+          # Testing Drupal 11 in php 8.3.
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.3"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Motivation
Enables jobs to test D11 readiness [RCAT-684](https://acquia.atlassian.net/browse/RCAT-684)

Proposed changes
Following jobs are added for D11 with php8.3 -

- ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
- INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
- ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
- INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
