### PR TITLE
HOTFIX: Commenting Release drafter until D11 is released.

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,16 +26,16 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_PR: ${{ steps.source-run-info.outputs.pullRequestNumber }}
-  update_release_draft:
-    needs: merge
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
-    steps:
-      - uses: release-drafter/release-drafter@v6
-        with:
-          publish: true
-          config-name: release-drafter.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#  update_release_draft:
+#    needs: merge
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: write
+#      pull-requests: read
+#    steps:
+#      - uses: release-drafter/release-drafter@v6
+#        with:
+#          publish: true
+#          config-name: release-drafter.yml
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,14 +18,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR: ${{ github.event.pull_request.number }}
-  update_release_draft:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
-    steps:
-      - uses: release-drafter/release-drafter@v6
-        with:
-          config-name: release-drafter.yml # located in .github/ in default branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#  update_release_draft:
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: write
+#      pull-requests: read
+#    steps:
+#      - uses: release-drafter/release-drafter@v6
+#        with:
+#          config-name: release-drafter.yml # located in .github/ in default branch
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Motivation**
The Release Drafter is creating `2.2.0` and `3.0.0` release from `master` branch. Looks like release drafter is not working as expected on beta releases. 

**Proposed changes**
Commenting the Release drafter code Until D11 stable release is made.

**Alternatives considered**
N/A

**Testing steps**
The release drafter shouldn't create any releases from `master` branch,
