### PR TITLE
Update README.md remove BLT

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,7 @@ To install Drupal 9, use the below command:
 composer create-project acquia/drupal-recommended-project:^1
 ```
 
-## Next steps
 
-After creating your project, if you'd also like to use Acquia BLT, do the
-following:
-* Add BLT via Composer with `composer require acquia/blt`
-* Install the [BLT Launcher](https://github.com/acquia/blt-launcher) and follow
-the rest of the
-[BLT setup guide](https://docs.acquia.com/blt/install/next-steps/).
-* Set up automated testing using BLT recipes and plugins such as
-[BLT Behat](https://github.com/acquia/blt-behat) and the
-[Acquia Drupal Spec Tool](https://github.com/acquia/drupal-spec-tool).
 
 # License
 


### PR DESCRIPTION
Removing the instructions for adding BLT from the README since BLT is incompatible with Drupal 11.

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Prevents confusion for folks reading the README for instructions for installing Drupal by removing installation instructions for BLT (which is no longer supported) 

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
No updates are required. Minimal impact on end users.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
This could potentially be resolved through some additional testing updates added to BLT to detect the version, and that probably exists, but this seems like a small change that would prevent teams from investing time or resources. 

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Check for BLT in the README.md code
