### PR TITLE
adding the drupal/mysql57 module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "drupal/config_sync_without_site_uuid": "^1.0@beta",
         "drupal/core-composer-scaffold": "^11",
         "drupal/core-recommended": "^11",
+        "drupal/mysql57": "^1.0",
         "drush/drush": "^13",
         "oomphinc/composer-installers-extender": "^2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "677a616e31a765a0ca7b65ff8a63b13c",
+    "content-hash": "50db02560e4197aff02c7820c0cce495",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -2315,6 +2315,50 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/memcache",
                 "issues": "https://www.drupal.org/project/issues/memcache"
+            }
+        },
+        {
+            "name": "drupal/mysql57",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/mysql57.git",
+                "reference": "1.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/mysql57-1.0.0.zip",
+                "reference": "1.0.0",
+                "shasum": "3d733fd6b0116999b110965d6dbf1c0f763d3f23"
+            },
+            "require": {
+                "drupal/core": "^10.2 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0",
+                    "datestamp": "1722631498",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "effulgentsia",
+                    "homepage": "https://www.drupal.org/user/78040"
+                }
+            ],
+            "description": "Database driver for MySQL with compatibility for MySQL 5.7.8 or higher and MariaDB 10.3.7 or higher.",
+            "homepage": "https://www.drupal.org/project/mysql57",
+            "support": {
+                "source": "https://git.drupalcode.org/project/mysql57"
             }
         },
         {


### PR DESCRIPTION
**Motivation**
Acquia requires the MySQL 5.7 backport module for Drupal 11. We should default to this if we are going to default to Drupal 11 in this package. 

**Proposed changes**
Adding the MySQL 5.7 module

**Alternatives considered**
Docs only

**Testing steps**
Make sure to follow the directions for the module (which requires adding a require line to settings). 
