### PR TITLE
Add recipe path in installer-path section to support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,6 +105,9 @@
             ],
             "drush/Commands/contrib/{$name}": [
                 "type:drupal-drush"
+            ],
+            "recipes/{$name}": [
+                "type:drupal-recipe"
             ]
         },
         "installer-types": [


### PR DESCRIPTION
This pull request includes a small change to the `composer.json` file. The change adds a new installer path for "recipes" with the type `drupal-recipe`.