### PR TITLE
Add patch for Acquia DAM module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,11 @@
         "patchLevel": {
             "drupal/core": "-p2"
         },
-        "patches": {}
+        "patches": {
+          "drupal/acquia_dam": {
+            "3553807 - Fatal error: Uncaught Error: Class AcquiaDamKernelTestBase not found in ORCA CI": "https://git.drupalcode.org/project/acquia_dam/-/merge_requests/211.patch"
+          }
+        }
     },
     "repositories": {
         "drupal": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d931db06b8a4303f19d37c5d9b8935c5",
+    "content-hash": "7e32515e2d12fdf47e60ffe36a5ce3c6",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",


### PR DESCRIPTION
This pull request adds a patch to the `composer.json` file to resolve a fatal error related to the `AcquiaDamKernelTestBase` class in the `drupal/acquia_dam` module during ORCA CI runs.

Dependency management:

* Added a new patch for `drupal/acquia_dam` to fix a fatal error (`Class AcquiaDamKernelTestBase not found`) in ORCA CI by referencing the upstream patch from the Drupal project.